### PR TITLE
DIS-18: Add dependency for running the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ By default:
 
 Running `./gradlew build` will generate PDF and HTML of the documentation.
 
+### Dependencies
+
+To run the plugin, you need to have `graphviz` installed on your machine.
+
+```
+sudo apt install graphviz
+```
+
 ### Jinja2 Context Map
 
 The context provided to the Jinja2 rendering engine has the following format:


### PR DESCRIPTION
When running `gradlew build` with this plugin, I was getting an error about missing dependencies:

```
java.io.IOException: Cannot run program "/opt/local/bin/dot": error=2, No such file or directory
```

This led to a StackOverflow [answer](https://github.com/sitoolkit/sit-cv/issues/85) stating that the dependency is likely part of `graphviz`.

Updated the README to explicitly state this dependency.