### PR TITLE
Feature/rad 149 gradle docs versioned pdf not working with multi module projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
     // Apply the Java plugin to add support for Java.
     id "java"
 
-    // Apply the Gradle-Baseline plugin for dependency checking.
+    // Apply the brightSPARK Labs plugin for standardisation.
     id "com.brightsparklabs.gradle.baseline" version "2.0.0"
 }
 
@@ -57,12 +57,6 @@ dependencies {
 // -----------------------------------------------------------------------------
 
 project.description = "Applies brightSPARK Labs standardisation to project documentation"
-project.group       = "com.brightsparklabs"
-
-def versionProcess  = "git describe --always --dirty".execute()
-versionProcess.waitFor()
-project.version     = versionProcess.exitValue() == 0 ? versionProcess.text.trim() : "0.0.0-UNKNOWN"
-
 project.ext.scm     = "https://github.com/brightsparklabs/gradle-docs.git"
 project.ext.url     = "https://github.com/brightsparklabs/gradle-docs"
 

--- a/src/main/groovy/com/brightsparklabs/gradle/docs/DocsPlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/docs/DocsPlugin.groovy
@@ -101,6 +101,12 @@ public class DocsPlugin implements Plugin<Project> {
             group = "brightSPARK Labs - Docs"
             description = "Performs Jinja2 pre-processing on documents"
 
+            String subProjectPath = "";
+            // Determine if the plugin is running in a sub-project and if so generate a sub-path
+            // to ensure that the file paths for getLastCommit accurately reflect their location
+            if(!(project.projectDir.toString() == project.rootDir.toString())) {
+                subProjectPath =   project.projectDir.toString() - project.rootDir.toString() - "/" + "/"
+            }
             doLast {
                 // Copy the entire directory and render files in-place to make
                 // keeping output folder structures intact easier.
@@ -131,7 +137,9 @@ public class DocsPlugin implements Plugin<Project> {
                     String yamlText = variablesFile.text
                     context.put('vars', yaml.load(yamlText))
 
-                    Map<String, Object> variablesFileLastCommit = getLastCommit(config.variablesFile, now)
+                    // subProjectPath adds the needed path prefix for when this plugin is ran in a sub-project
+                    // When it's not run in a sub-project a string of "" is provided which causes no change to the path
+                    Map<String, Object> variablesFileLastCommit = getLastCommit(subProjectPath+config.variablesFile, now)
                     context.put('vars_file_last_commit', variablesFileLastCommit)
                 }
                 else {
@@ -150,7 +158,9 @@ public class DocsPlugin implements Plugin<Project> {
                             jinjaOutputDir.toString(),
                             new File(config.docsDir).toString() // NOTE: this cleanly removes trailing slashes
                             )
-                    Map<String, Object> templateFileLastCommit = getLastCommit(templateSrcFile, now)
+                    // subProjectPath adds the needed path prefix for when this plugin is ran in a sub-project
+                    // When it's not run in a sub-project a string of "" is provided which causes no change to the path
+                    Map<String, Object> templateFileLastCommit = getLastCommit(subProjectPath+templateSrcFile, now)
                     String templateOutputFileName = templateFile.getName().replaceFirst(/\.j2$/, '')
                     File templateOutputFile = new File(templateFile.getParent(), templateOutputFileName)
                     Map<String, Object> templateFileContext = [
@@ -179,7 +189,9 @@ public class DocsPlugin implements Plugin<Project> {
                                 jinjaOutputDir.toString(),
                                 new File(config.docsDir).toString() // NOTE: This cleanly removes trailing slashes.
                                 ) + '.yaml'
-                        Map<String, Object> fileVariablesFileLastCommit = getLastCommit(fileVariablesSrcFile, now)
+                        // subProjectPath adds the needed path prefix for when this plugin is ran in a sub-project
+                        // When it's not run in a sub-project a string of "" is provided which causes no change to the path
+                        Map<String, Object> fileVariablesFileLastCommit = getLastCommit(subProjectPath+fileVariablesSrcFile, now)
                         templateFileContext.put('vars_file_last_commit', fileVariablesFileLastCommit)
                         if (fileVariablesFileLastCommit.timestamp.isAfter(templateFileContext.last_commit.timestamp)) {
                             outputFileContext.last_commit = fileVariablesFileLastCommit
@@ -202,7 +214,9 @@ public class DocsPlugin implements Plugin<Project> {
                                     jinjaOutputDir.toString(),
                                     new File(config.docsDir).toString() // NOTE: This cleanly removes trailing slashes.
                                     )
-                            Map<String, Object> instanceFileLastCommit = getLastCommit(instanceSrcFile, now)
+                            // subProjectPath adds the needed path prefix for when this plugin is ran in a sub-project
+                            // When it's not run in a sub-project a string of "" is provided which causes no change to the path
+                            Map<String, Object> instanceFileLastCommit = getLastCommit(subProjectPath+instanceSrcFile, now)
                             // We want to output the file at the same level as the template file.
                             String instanceOutputFileName = instanceFile.getName().replaceFirst(/\.yaml$/, '')
                             File instanceOutputFile = new File(templateFile.getParent(), instanceOutputFileName)

--- a/src/main/groovy/com/brightsparklabs/gradle/docs/DocsPlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/docs/DocsPlugin.groovy
@@ -193,7 +193,8 @@ public class DocsPlugin implements Plugin<Project> {
                         // When it's not run in a sub-project a string of "" is provided which causes no change to the path
                         Map<String, Object> fileVariablesFileLastCommit = getLastCommit(subProjectPath+fileVariablesSrcFile, now)
                         templateFileContext.put('vars_file_last_commit', fileVariablesFileLastCommit)
-                        if (fileVariablesFileLastCommit.timestamp.isAfter(templateFileContext.last_commit.timestamp)) {
+                        // Make sure that if we want to replace the commit hash that it actually has a commit hash to replace it with.
+                        if (fileVariablesFileLastCommit.timestamp.isAfter(templateFileContext.last_commit.timestamp) && fileVariablesFileLastCommit.hash != "unspecified") {
                             outputFileContext.last_commit = fileVariablesFileLastCommit
                         }
                         fileVariables.delete()
@@ -238,7 +239,7 @@ public class DocsPlugin implements Plugin<Project> {
 
                             // Cache current last commit so next instance can cleanly compare.
                             def cachedLastCommit = outputFileContext.last_commit
-                            if (instanceFileLastCommit.timestamp.isAfter(cachedLastCommit.timestamp)) {
+                            if (instanceFileLastCommit.timestamp.isAfter(cachedLastCommit.timestamp) && instanceFileLastCommit.hash != "unspecified"){
                                 outputFileContext.last_commit = instanceFileLastCommit
                             }
 


### PR DESCRIPTION
In addition to the solution to the multi-module project issues I also encountered and addressed a bug where locally generated files were overriding the commit hashes for their corresponding documents due to the hash update only checking to see if it's timestamp more recent and not checking to see if it has a non-default value ('unspecified'). For a more in depth write-up please refer to the Jira ticket comment I made on the subject under RAD-149.

Testing for this change has been conducted against the REDACTED branch as a single module project and against teraflow as a multi-module project. 